### PR TITLE
Copy the generation of the file we scanned to the quarantine bucket.

### DIFF
--- a/src/filter.go
+++ b/src/filter.go
@@ -77,7 +77,7 @@ func analyzeObject(ctx context.Context, e event.Event) error {
 	endTimer = perf.Timer("ScanObject")
 	logging.Info("starting analysis: object_name=\"%v\"", objectName)
 	object := storageClient.Bucket(bucketName).Object(objectName)
-	leaks, err := scanner.Scan(ctx, cfg.Gitleaks, bucketName, objectName, object)
+	leaks, generation, err := scanner.Scan(ctx, cfg.Gitleaks, bucketName, objectName, object)
 	if err != nil {
 		logging.Error("scanner.Scan: %w", err)
 	}
@@ -100,7 +100,7 @@ func analyzeObject(ctx context.Context, e event.Event) error {
 	endTimer()
 
 	if leakRedactor.Enabled && leakFound {
-		err = leakRedactor.Redact(ctx, objectName, object)
+		err = leakRedactor.Redact(ctx, objectName, object, generation)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
This change intends to avoid a race condition that occurs when we redact the contents of a file before the copy operation has completed.